### PR TITLE
WIP implementation of standard API functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,49 @@ pkg> add Mimi
 ## Running the model
 
 The model uses the Mimi framework and it is highly recommended to read the Mimi documentation first to understand the code structure. For starter code on running the model just once, see the code in the file `examples/main.jl`.
+
+The basic way to access a copy of the default MimiDICE2010 model is the following:
+```
+using MimiDICE2010
+
+m = MimiDICE2010.get_model()
+run(m)
+```
+
+## Calculating the Social Cost of Carbon
+
+Here is an example of computing the social cost of carbon with MimiDICE2010. Note that the units of the returned value are dollars $/ton CO2.
+```
+using Mimi
+using MimiDICE2010
+
+# Get the social cost of carbon in year 2015 from the default MimiDICE2010 model:
+scc = MimiDICE2010.compute_scc(year = 2015)
+
+# You can also compute the SCC from a modified version of a MimiDICE2010 model:
+m = MimiDICE2010.get_model()    # Get the default version of the MimiDICE2010 model
+update_param!(m, :t2xco2, 5)    # Try a higher climate sensitivity value
+scc = MimiDICE2010.compute_scc(m, year=2015)    # compute the scc from the modified model by passing it as the first argument to compute_scc
+```
+The first argument to the `compute_scc` function is a MimiDICE2010 model, and it is an optional argument. If no model is provided, the default MimiDICE2010 model will be used. 
+There are also other keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
+```
+compute_scc(m = get_model(),  # if no model provided, will use the default MimiDICE2010 model
+    year = nothing,  # user must specify an emission year for the SCC calculation
+    last_year = 2595,  # the last year to run and use for the SCC calculation. Default is the last year of the time dimension, 2595.
+    prtp = 0.03,  # pure rate of time preference parameter used for constant discounting
+)
+```
+There is an additional function for computing the SCC that also returns the MarginalModel that was used to compute it. It returns these two values as a NamedTuple of the form (scc=scc, mm=mm). The same keyword arguments from the `compute_scc` function are available for the `compute_scc_mm` function. Example:
+```
+using Mimi
+using MimiDICE2010
+
+result = MimiDICE2010.compute_scc_mm(year=2025, last_year=2295, prtp=0.025)
+
+result.scc  # returns the computed SCC value
+
+result.mm   # returns the Mimi MarginalModel
+
+marginal_temp = result.mm[:climatedynamics, :TATM]  # marginal results from the marginal model can be accessed like this
+```

--- a/examples/main.jl
+++ b/examples/main.jl
@@ -1,7 +1,7 @@
 using Mimi
 using MimiDICE2010
 
-DICE = construct_dice()
+DICE = MimiDICE2010.get_model()
 run(DICE)
 
 explore(DICE)

--- a/src/MimiDICE2010.jl
+++ b/src/MimiDICE2010.jl
@@ -21,7 +21,7 @@ export construct_dice
 # Allow these to be accessed by, e.g., EPA DICE model
 const model_years = 2005:10:2595
 
-function construct_dice(params=nothing)
+function get_model(params=nothing)
     p = params == nothing ? dice2010_excel_parameters() : params
 
     m = Model()
@@ -148,5 +148,7 @@ function construct_dice(params=nothing)
 
     return m
 end
+
+construct_dice = get_model # still export the old version of the function name
 
 end #module

--- a/src/marginaldamage.jl
+++ b/src/marginaldamage.jl
@@ -1,5 +1,5 @@
 """
-compute_scc(m::Model=get_model(); year::Int = nothing, last_year::Int = $(model_years[end]), prtp::Float64 = 0.03)
+compute_scc(m::Model=get_model(); year::Int = nothing, last_year::Int = 2595), prtp::Float64 = 0.03)
 
 Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiDICE2010 model. 
 If no model is provided, the default model from MimiDICE2010.get_model() is used.
@@ -21,7 +21,7 @@ function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, 
 end
 
 """
-compute_scc_mm(m::Model=get_model(); year::Int = nothing, last_year::Int = $(model_years[end]), prtp::Float64 = 0.03)
+compute_scc_mm(m::Model=get_model(); year::Int = nothing, last_year::Int = 2595, prtp::Float64 = 0.03)
 
 Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
 Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiDICE2010 model. 

--- a/src/marginaldamage.jl
+++ b/src/marginaldamage.jl
@@ -1,6 +1,93 @@
+"""
+compute_scc(m::Model=get_model(); year::Int = nothing, last_year::Int = $(model_years[end]), prtp::Float64 = 0.03)
+
+Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiDICE2010 model. 
+If no model is provided, the default model from MimiDICE2010.get_model() is used.
+Constant discounting is used from the specified pure rate of time preference `prtp`.
+
+TODO:
+- do we want to implement interpolation if the ask for an SCC value between the timestep values? currently errors
+- do we want to implement ramsey discounting, i.e. offer the eta keyword argument as well? 
+- should marginal damages be a step function across the ten year timesteps to be used by the SCC? or should I lineraly interpolate to get annual marginal emissions?
+"""
+function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = model_years[end], prtp::Float64 = 0.03)
+    year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2015)`.") : nothing
+    !(last_year in model_years) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index $model_years.") : nothing
+    !(year in model_years[1]:10:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index $(model_years[1]):10:$last_year.") : nothing
+
+    mm = get_marginal_model(m; year = year)
+
+    return _compute_scc(mm, year=year, last_year=last_year, prtp=prtp)
+end
+
+"""
+compute_scc_mm(m::Model=get_model(); year::Int = nothing, last_year::Int = $(model_years[end]), prtp::Float64 = 0.03)
+
+Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
+Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiDICE2010 model. 
+If no model is provided, the default model from MimiDICE2010.get_model() is used.
+Constant discounting is used from the specified pure rate of time preference `prtp`.
+"""
+function compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = model_years[end], prtp::Float64 = 0.03)
+    year === nothing ? error("Must specify an emission year. Try `compute_scc_mm(m, year=2015)`.") : nothing
+    !(last_year in model_years) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index $model_years.") : nothing
+    !(year in model_years[1]:10:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index $(model_years[1]):10:$last_year.") : nothing
+
+    mm = get_marginal_model(m; year = year)
+    scc = _compute_scc(mm; year=year, last_year=last_year, prtp=prtp)
+    
+    return (scc = scc, mm = mm)
+end
+
+# helper function for computing SCC from a MarginalModel, not to be exported or advertised to users
+function _compute_scc(mm::MarginalModel; year::Int, last_year::Int, prtp::Float64)
+    ntimesteps = findfirst(isequal(last_year), model_years)     # Will run through the timestep of the specified last_year 
+    run(mm, ntimesteps=ntimesteps)
+
+    marginal_damages = -1 * mm[:neteconomy, :C][1:ntimesteps] * 12/44 * 10^2     # consumption is in trillions$, so *10^12, but pulse is in GtC for ten years, so *10^-9 *10^-1
+
+    df = [zeros(length(model_years[1]:10:year)-1)..., [1/(1+prtp)^(t-year) for t in year:10:last_year]...]
+    scc = sum(df .* marginal_damages * 10)  # currently implemented as a 10year step function; so each timestep of discounted marginal damages is multiplied by 10
+    return scc
+end
+
+"""
+get_marginal_model(m::Model = get_model(); year::Int = nothing)
+
+Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of CO2 in year `year`.
+If no Model m is provided, the default model from MimiDICE2010.get_model() is used as the base model.
+"""
+function get_marginal_model(m::Model=get_model(); year::Union{Int, Nothing} = nothing)
+    year === nothing ? error("Must specify an emission year. Try `get_marginal_model(m, year=2015)`.") : nothing
+    !(year in model_years) ? error("Cannot add marginal emissions in $year, year must be within the model's time index $(model_years[1]):10:$last_year.") : nothing
+
+    mm = create_marginal_model(m)
+    add_marginal_emissions!(mm.marginal, year)
+
+    return mm
+end
+
+"""
+Adds a marginal emission component to year m which adds 1Gt of additional C emissions per year for ten years starting in the specified `year`.
+"""
+function add_marginal_emissions!(m::Model, year::Int) 
+    add_comp!(m, Mimi.adder, :marginalemission, before=:co2cycle)
+
+    time = Mimi.dimension(m, :time)
+    addem = zeros(length(time))
+    addem[time[year]] = 1.0     # 1 GtC per year for ten years
+
+    set_param!(m, :marginalemission, :add, addem)
+    connect_param!(m, :marginalemission, :input, :emissions, :E)
+    connect_param!(m, :co2cycle, :E, :marginalemission, :output)
+end
+
+
+
+# Old available function
 function getmarginal_dice_models(;emissionyear=2015)
 
-    DICE = construct_dice()
+    DICE = get_model()
     run(DICE)
 
     mm = MarginalModel(DICE)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ Precision = 1.0e-11
 T = 60
 f = openxl(joinpath(@__DIR__, "..", "Data", "DICE2010_082710d.xlsx"))
 
-m = construct_dice()
+m = MimiDICE2010.get_model()
 run(m)
 
 # Climate dynamics tests
@@ -187,7 +187,7 @@ Precision = 1.0e-11
 nullvalue = -999.999
 T = 60
 
-m = construct_dice()
+m = MimiDICE2010.get_model()
 run(m)
 
 for c in map(name, Mimi.compdefs(m)), v in Mimi.variable_names(m, c)
@@ -220,6 +220,47 @@ for c in map(name, Mimi.compdefs(m)), v in Mimi.variable_names(m, c)
 end #for loop
 
 end #dice2010-integration testset
+
+#------------------------------------------------------------------------------
+#   4. Test standard api functions and SCC functions
+#------------------------------------------------------------------------------
+
+@testset "Standard API functions" begin 
+
+m = MimiDICE2010.get_model()
+run(m)
+
+# Test the errors
+@test_throws ErrorException MimiDICE2010.compute_scc()  # test that it errors if you don't specify a year
+@test_throws ErrorException MimiDICE2010.compute_scc(year=2020)  # test that it errors if the year isn't in the time index
+@test_throws ErrorException MimiDICE2010.compute_scc(last_year=2300)  # test that it errors if the last_year isn't in the time index
+@test_throws ErrorException MimiDICE2010.compute_scc(year=2105, last_year=2100)  # test that it errors if the year is after last_year
+
+# Test the SCC 
+scc1 = MimiDICE2010.compute_scc(year=2015)
+@test scc1 isa Float64
+
+# Test that it's smaller with a shorter horizon
+scc2 = MimiDICE2010.compute_scc(year=2015, last_year=2295)
+@test scc2 < scc1
+
+# Test that it's larger with a smalle prtp
+scc3 = MimiDICE2010.compute_scc(year=2015, last_year=2295, prtp=0.02)
+@test scc3 > scc2
+
+# Test with a modified model 
+m = MimiDICE2010.get_model()
+update_param!(m, :t2xco2, 5)    
+scc4 = MimiDICE2010.compute_scc(m, year=2015)
+@test scc4 > scc1   # Test that a higher value of climate sensitivty makes the SCC bigger
+
+# Test compute_scc_mm
+result = MimiDICE2010.compute_scc_mm(year=2035)
+@test result.scc isa Float64
+@test result.mm isa Mimi.MarginalModel
+
+
+end
 
 end #mimi-dice-2010 testset
 


### PR DESCRIPTION
@davidanthoff Questions:
- What should happen if the user calls `compute_scc` for a year not in the model's time index? the index is 2005:10:2595. Currently if they call `compute_scc(year=2020)` this will error and say they need to provide a valid year. Do we want to implement interpolation so that if they request a 2020 SCC value, it would interpolate between a 2015 SCC value and a 2025 SCC value? this would cause problems for the `compute_scc_mm` function since more than one marginalmodel is used.
- Do we want to implement Ramsey discounting option? Currently the only available discounting keyword argument is `prtp` and constant discounting is used.
- Since there's currently no ramsey discounting, I made the default prtp value be 0.03. Let me know if I should change this.
- How exactly do we want to calculate the SCC since marginal damages are on 10 year timesteps? Currently I implemented the simplest way of just discounting each 10yr value then multiplying each value by ten. Alternatively, we could interpolate (or do a step function) to have annual marginal damages, then discount each annual marginal damage value.

And I still need to update the README