### PR TITLE
Change emissions comments from GtCO2 to GtC

### DIFF
--- a/src/components/co2cycle_component.jl
+++ b/src/components/co2cycle_component.jl
@@ -4,7 +4,7 @@
     ML      = Variable(index=[time])    #Carbon concentration increase in lower oceans (GtC from 1750)
     MU      = Variable(index=[time])    #Carbon concentration increase in shallow oceans (GtC from 1750)
 
-    E       = Parameter(index=[time])   #Total CO2 emissions (GtCO2 per year)
+    E       = Parameter(index=[time])   #Total CO2 emissions (GtC per year)
     mat0    = Parameter()               #Initial Concentration in atmosphere 2000 (GtC)
     mat1    = Parameter()               #Concentration 2010 (GtC)
     ml0     = Parameter()               #Initial Concentration in lower strata (GtC)

--- a/src/components/emissions_component.jl
+++ b/src/components/emissions_component.jl
@@ -1,7 +1,7 @@
 @defcomp emissions begin
     CCA     = Variable(index=[time])    #Cumulative indiustrial emissions
-    E       = Variable(index=[time])    #Total CO2 emissions (GtCO2 per year)
-    EIND    = Variable(index=[time])    #Industrial emissions (GtCO2 per year)
+    E       = Variable(index=[time])    #Total CO2 emissions (GtC per year)
+    EIND    = Variable(index=[time])    #Industrial emissions (GtC per year)
 
     etree   = Parameter(index=[time])   #Emissions from deforestation
     MIU     = Parameter(index=[time])   #Emission control rate GHGs


### PR DESCRIPTION
I *think* that just these comments were incorrect, because when I initially created dice2010, I started from the dice2013 Mimi code. Is it true that:
- emissions in dice 2010 are GtC per year
- emissions in dice2013 are GtCO2 per year

We should confirm this is true, but this is how I've treated it for the SCC calcualtions. (i.e. we have to multiply marginal damages by (12/44 in dice2010 but not in dice2013)