### PR TITLE
Fix scc bug

### DIFF
--- a/src/marginaldamage.jl
+++ b/src/marginaldamage.jl
@@ -41,7 +41,7 @@ function _compute_scc(mm::MarginalModel; year::Int, last_year::Int, prtp::Float6
     ntimesteps = findfirst(isequal(last_year), model_years)     # Will run through the timestep of the specified last_year 
     run(mm, ntimesteps=ntimesteps)
 
-    marginal_damages = -1 * mm[:neteconomy, :C][1:ntimesteps] * 10^12 * 12/44 # convert from trillion $/ton C to $/ton CO2; multiply by -1 to get positive value for damages
+    marginal_damages = -1 * mm[:neteconomy, :C][1:ntimesteps] * 1e12 * 12/44 # convert from trillion $/ton C to $/ton CO2; multiply by -1 to get positive value for damages
 
     cpc = mm.base[:neteconomy, :CPC]
 


### PR DESCRIPTION
I'm really surprised we didn't notice this sooner, but for a while our `compute_scc` function has been returning completely incorrect numbers because of this (it was returning -$0.027 instead of $37 for year=2015, prtp-0.03, eta=0).

For reference, I think it was this commit a while ago that broke it: https://github.com/anthofflab/MimiDICE2010.jl/commit/6cf264d4abbca776758708fa9842312c2e53f41c